### PR TITLE
macos向けのInternetパーミッション指定: (httpパッケージ利用)

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
# issues (任意)

# 修正内容 (必須)
macos向けのインターネットパーミッションの設定追加。
これがないと通信処理できない。

# capture (任意)

| before | after |
|:---|:---:|
|<img src="" width=320 /> |<img src="" width=320 /> |

# refs (任意)
